### PR TITLE
fix: regular expression

### DIFF
--- a/src/PadsJson.php
+++ b/src/PadsJson.php
@@ -44,7 +44,7 @@ trait PadsJson
             return $tmpJson;
         }
 
-        $match = \preg_match('/(tr?u?e?|fa?l?s?e|nu?l?l?)$/', $tmpJson, $matches);
+        $match = \preg_match('/(tr?u?e?|fa?l?s?e?|nu?l?l?)$/', $tmpJson, $matches);
 
         if (!$match || null === $literal = $this->maybeLiteral($matches[1])) {
             return $tmpJson;


### PR DESCRIPTION
Due to a missing question mark the regular expression does not match strings ending with fa, fal, fals but only fae, fale and false.