### PR TITLE
Fix string including comma

### DIFF
--- a/src/PadsJson.php
+++ b/src/PadsJson.php
@@ -71,7 +71,7 @@ trait PadsJson
         }
 
         $part = \substr($tmpJson, $this->objectPos + 1);
-        if (\preg_match('/(\s*\"[^"]+\"\s*:\s*[^,]+,?)+$/', $part, $matches)) {
+        if (\preg_match('/(\s*\"[^"]+\"\s*:\s*([^,]+|\"(?:.(?!(?<![\\\\])"))*.?"?),?)+$/', $part, $matches)) {
             return $tmpJson;
         }
 

--- a/tests/FixerTest.php
+++ b/tests/FixerTest.php
@@ -160,6 +160,9 @@ class FixerTest extends \PHPUnit\Framework\TestCase
         ], [
             'json'   => '[ {"id":1, "data": []}, {"id":2, "data": [',
             'expect' => '[ {"id":1, "data": []}, {"id":2, "data": []}]',
+        ], [
+            'json'   => '[ {"id":1, "data": []}, {"id":2, "data": "bla,',
+            'expect' => '[ {"id":1, "data": []}, {"id":2, "data": "bla,"}]',
         ],
         ];
     }


### PR DESCRIPTION
A small fix, so that an incomplete json like `{"id":2, "data": "bla,` is fixed correctly.